### PR TITLE
Updated history to version 1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "history": "1.12.0",
+    "history": "1.12.1",
     "koa": "1.0.0",
     "koa-router": "5.2.3",
     "koa-static": "1.4.9",


### PR DESCRIPTION
:rocket:

history just published version 1.12.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 11 commits (ahead by 11, behind by 0).
- [0f65e2a](https://github.com/rackt/history/commit/0f65e2a1099afb6eec87ebce67971b570fdf4ee5): Version 1.12.1
- [8887d5a](https://github.com/rackt/history/commit/8887d5a246a1bed8aba7884eb3c8dc339c75643f): Give locations a key by default
- [b0f6d12](https://github.com/rackt/history/commit/b0f6d12089bb91d30338d081e9874aeb7bf331a0): Update expect dep
- [2cf9500](https://github.com/rackt/history/commit/2cf95006fbb2d790ebe652a7860af713594f3e13): Small tweaks
- [802048c](https://github.com/rackt/history/commit/802048c75beab7fd5035310a2d2b5023c26a8423): Remove tests for deprecated setState
- [f1a6de6](https://github.com/rackt/history/commit/f1a6de6e7f09d2450df00b4ac7433d6dc1ecac5b): Update README
- [3fd8224](https://github.com/rackt/history/commit/3fd8224cfebfde995fe9d642e5510190e8fa1ab4): Improve readability
- [ed379c9](https://github.com/rackt/history/commit/ed379c9d9c0847e51535828099290b175c22ea77): Deprecate setState
- [2e6e7e1](https://github.com/rackt/history/commit/2e6e7e187f817935940917dfce628feef018d442): Remove LICENSE file
- [32e68f6](https://github.com/rackt/history/commit/32e68f6a8eaef297a6ec9e8309177d06c152c45d): Add CHANGES file
- [319da5b](https://github.com/rackt/history/commit/319da5bcd347943e806d4d7a21d7686fcc238ca6): Update manual test page

See the [full diff](https://github.com/rackt/history/compare/de6febdf33fca3a62954ea39ff5bb6d6967e8c3b...0f65e2a1099afb6eec87ebce67971b570fdf4ee5).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
